### PR TITLE
Makefile change for Archer2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ RANLIB = ranlib
 # Get host for machine-specific build instructions
 host = $(shell hostname | awk '{if     (/typhon/)  print "typhon"; \
                                else if (/eslogin/) print "archer"; \
+			       else if (/uan/)     print "archer2"; \
                                else                print "other"}')
 
 # Need to link FFFTW against FFTW3
@@ -34,6 +35,9 @@ ifeq ($(host),typhon)
 endif
 # Flags which work on ARCHER (must `module load fftw`)
 ifeq ($(host),archer)
+    FFFTWOPTS = -I${FFTW_INC} -L${FFTW_DIR} -lfftw3 -lfftw3f
+endif
+ifeq ($(host),archer2)
     FFFTWOPTS = -I${FFTW_INC} -L${FFTW_DIR} -lfftw3 -lfftw3f
 endif
 


### PR DESCRIPTION
Archer2 is the new Cray machine replacing Archer in the UK. This
change allows make to detect when sesimo-fortran is being built
on an Archer2 login node, and links to the supplied FFTW.

Use the gnu programming environment to build thusly:

    module restore PrgEnv-gnu
    module load cray-fftw
    make CC=cc FC=ftn

and add lib to LD_LIBRARY_PATH. This must be on one of the
work file systems to run via the batch queues.